### PR TITLE
Hover-over Effect on Pancake Menu

### DIFF
--- a/src/comps/ui/nav/NavBar.tsx
+++ b/src/comps/ui/nav/NavBar.tsx
@@ -89,7 +89,8 @@ const NavBar = () => {
             <Box sx={navStyles}>
                 <Button
                     onClick={() => setDrawerOpen(!drawerOpen)}
-                    sx={{ borderRadius: "100%", width: "50px" }}
+                    style={{maxWidth: '50px', maxHeight: '50px', minWidth: '50px', minHeight: '50px'}}
+                    sx={ { borderRadius: 50 } }
                 >
                     <Menu />
                 </Button>


### PR DESCRIPTION
Fixed issue of hover-over effect on pancake menu for NavBar appearing as an oval instead of a circle. 
Fixes #123 