### PR TITLE
Key Combination to Submit an Announcement

### DIFF
--- a/src/pages/admin/Announcements.tsx
+++ b/src/pages/admin/Announcements.tsx
@@ -73,7 +73,7 @@ const Announcements = () => {
                         label="Content"
                         onChange={(e) => setContent(e.target.value)}
                         onKeyDown={(e) => {
-                            if (e.key === "Enter") {
+                            if (e.key === 'Enter' && e.ctrlKey) {
                                 e.preventDefault();
 
                                 createAnnouncement();


### PR DESCRIPTION
Removed functionality of pressing <ENTER> to submit an announcement as requested, and instead added functionality of pressing <CTRL + ENTER> to submit an announcement.

Fixes #129 