### PR TITLE
Fixes #142 - Newlines don't render on announcements

### DIFF
--- a/src/pages/Catalog.tsx
+++ b/src/pages/Catalog.tsx
@@ -226,7 +226,13 @@ const Catalog = () => {
                                     padding: "20px",
                                 }}
                             >
-                                <Typography variant="body1" width="100%">
+                                <Typography
+                                    variant="body1"
+                                    sx={{
+                                        width: "100%",
+                                        whiteSpace: "pre-line",
+                                    }}
+                                >
                                     {announcement.content}
                                 </Typography>
                             </Card>

--- a/src/pages/admin/Announcements.tsx
+++ b/src/pages/admin/Announcements.tsx
@@ -1,14 +1,11 @@
 import { Box, TextField, Typography, Button, Card } from "@mui/material";
 import { useSnackbar } from "notistack";
-
 import { useEffect, useState } from "react";
-
 import { supabase } from "../../supabaseClient";
 
 const Announcements = () => {
     let [content, setContent] = useState("");
     let { enqueueSnackbar } = useSnackbar();
-
     let [announcements, setAnnouncements] = useState<Announcement[]>([]);
 
     useEffect(() => {
@@ -103,7 +100,6 @@ const Announcements = () => {
                         onKeyDown={(e) => {
                             if (e.key === "Enter" && e.ctrlKey) {
                                 e.preventDefault();
-
                                 createAnnouncement();
                             }
                         }}
@@ -147,7 +143,13 @@ const Announcements = () => {
                                     alignItems: "center",
                                 }}
                             >
-                                <Typography variant="body1" width="80%">
+                                <Typography
+                                    variant="body1"
+                                    sx={{
+                                        width: "80%",
+                                        whiteSpace: "pre-line",
+                                    }}
+                                >
                                     {announcement.content}
                                 </Typography>
                                 <Button


### PR DESCRIPTION
Renders newlines in announcements by editing Typography component with the pre-line CSS property.