### PR TITLE
Fixes #143 - Adds snackbar notification if user tries to input more than 3 keywords

### DIFF
--- a/src/comps/ui/forms/FormChipText.tsx
+++ b/src/comps/ui/forms/FormChipText.tsx
@@ -6,6 +6,7 @@ import {
     KeyboardEvent,
     useRef,
 } from "react";
+import { useSnackbar } from "notistack";
 
 type Requirements = {
     maxChips?: number;
@@ -40,6 +41,7 @@ const FormChipText = ({
 }: Props) => {
     const [inputValue, setInputValue] = useState("");
     const inputRef = useRef<HTMLInputElement | null>(null);
+    const { enqueueSnackbar } = useSnackbar();
 
     useEffect(() => {
         const validate = (newValue?: string[]) => {
@@ -61,6 +63,9 @@ const FormChipText = ({
 
     const valueChanged = (event: SyntheticEvent, newValue: string[]) => {
         if (requirements?.maxChips && newValue.length > requirements.maxChips) {
+            enqueueSnackbar("You can enter up to 3 keywords only.", {
+                variant: "error",
+            });
             return;
         }
 

--- a/src/comps/ui/forms/FormTagSelect.tsx
+++ b/src/comps/ui/forms/FormTagSelect.tsx
@@ -1,5 +1,6 @@
 import { Autocomplete, TextField, Chip, SxProps } from "@mui/material";
 import { SyntheticEvent, useEffect } from "react";
+import { useSnackbar } from "notistack";
 
 type Requirements = {
     maxSelect?: number;
@@ -34,6 +35,8 @@ const FormTagSelect = ({
     label,
     sx,
 }: Props) => {
+    const { enqueueSnackbar } = useSnackbar();
+
     useEffect(() => {
         const validate = (newValue?: string[]) => {
             if (!changeStatus) return;
@@ -57,6 +60,9 @@ const FormTagSelect = ({
             requirements?.maxSelect &&
             newValue.length > requirements.maxSelect
         ) {
+            enqueueSnackbar("You can select up to 3 tags only.", {
+                variant: "error",
+            });
             return;
         }
 
@@ -82,11 +88,11 @@ const FormTagSelect = ({
                     label={label}
                     value={undefined}
                     {...params}
-                    helperText={description?.split("\n").map((line) => (
-                        <>
+                    helperText={description?.split("\n").map((line, i) => (
+                        <span key={i}>
                             {line}
                             <br />
-                        </>
+                        </span>
                     ))}
                 />
             )}


### PR DESCRIPTION
It seems that the original issue "Reject plaintext input on the keywords menu once all 3 keywords have been filled" was already fixed beforehand. @SnowyNate wanted to have error notifications if user tries to input more than 3 keywords, so a snackbar error notification was implemented for the input text and tags.