### PR TITLE
Fixes #124 - Bad announcement behavior

### DIFF
--- a/src/pages/Catalog.tsx
+++ b/src/pages/Catalog.tsx
@@ -162,8 +162,8 @@ const Catalog = () => {
             const { data, error } = await supabase
                 .from("announcements")
                 .select("*")
-                .order("created_at", { ascending: false }); // Sort by created_at in descending order
-
+                .order('created_at', { ascending: false });
+    
             if (error || !data) {
                 enqueueSnackbar(
                     "Failed to load announcements. Contact it@stuysu.org for support.",
@@ -171,23 +171,19 @@ const Catalog = () => {
                 );
                 return;
             }
-
+    
             setAnnouncements(data as Announcement[]);
         };
-
+    
         fetchAnnouncements();
     }, [enqueueSnackbar, setAnnouncements]);
-    /*
+        /*
   Testing
   useEffect(() => {
     console.log(`${orgs.length} orgs!`)
     console.log(`${Object.keys(getUnique(orgs)).length} unique orgs!`);
   }, [orgs])
   */
-
-    const loadMoreAnnouncements = () => {
-        setVisibleAnnouncements((prev) => prev + 2);
-    };
 
     let approvedOrgs = searchState.orgs.filter(
         (o) => o.state !== "PENDING" && o.state !== "LOCKED",
@@ -219,32 +215,30 @@ const Catalog = () => {
                     }}
                 >
                     <Typography variant="h3">Announcements</Typography>
-                    {announcements
-                        .slice(0, visibleAnnouncements)
-                        .map((announcement, i) => {
-                            return (
-                                <Card
-                                    key={i}
+                    {announcements.slice(0, visibleAnnouncements).map((announcement, i) => {
+                        return (
+                            <Card
+                                key={i}
+                                sx={{
+                                    width: "100%",
+                                    display: "flex",
+                                    justifyContent: "center",
+                                    marginTop: "10px",
+                                    padding: "20px",
+                                }}
+                            >
+                                <Typography
+                                    variant="body1"
                                     sx={{
                                         width: "100%",
-                                        display: "flex",
-                                        justifyContent: "center",
-                                        marginTop: "10px",
-                                        padding: "20px",
+                                        whiteSpace: "pre-line",
                                     }}
                                 >
-                                    <Typography
-                                        variant="body1"
-                                        sx={{
-                                            width: "100%",
-                                            whiteSpace: "pre-line",
-                                        }}
-                                    >
-                                        {announcement.content}
-                                    </Typography>
-                                </Card>
-                            );
-                        })}
+                                    {announcement.content}
+                                </Typography>
+                            </Card>
+                        );
+                    })}
                     {visibleAnnouncements < announcements.length && (
                         <Box
                             sx={{
@@ -256,7 +250,9 @@ const Catalog = () => {
                         >
                             <Button
                                 variant="contained"
-                                onClick={loadMoreAnnouncements}
+                                onClick={() =>
+                                    setVisibleAnnouncements((prev) => prev + 2)
+                                }
                             >
                                 Show More
                             </Button>

--- a/src/pages/Catalog.tsx
+++ b/src/pages/Catalog.tsx
@@ -162,7 +162,7 @@ const Catalog = () => {
             const { data, error } = await supabase
                 .from("announcements")
                 .select("*")
-                .order('created_at', { ascending: false });
+                .order("created_at", { ascending: false });
 
             if (error || !data) {
                 enqueueSnackbar(
@@ -177,7 +177,7 @@ const Catalog = () => {
 
         fetchAnnouncements();
     }, [enqueueSnackbar, setAnnouncements]);
-        /*
+    /*
   Testing
   useEffect(() => {
     console.log(`${orgs.length} orgs!`)
@@ -215,30 +215,32 @@ const Catalog = () => {
                     }}
                 >
                     <Typography variant="h3">Announcements</Typography>
-                    {announcements.slice(0, visibleAnnouncements).map((announcement, i) => {
-                        return (
-                            <Card
-                                key={i}
-                                sx={{
-                                    width: "100%",
-                                    display: "flex",
-                                    justifyContent: "center",
-                                    marginTop: "10px",
-                                    padding: "20px",
-                                }}
-                            >
-                                <Typography
-                                    variant="body1"
+                    {announcements
+                        .slice(0, visibleAnnouncements)
+                        .map((announcement, i) => {
+                            return (
+                                <Card
+                                    key={i}
                                     sx={{
                                         width: "100%",
-                                        whiteSpace: "pre-line",
+                                        display: "flex",
+                                        justifyContent: "center",
+                                        marginTop: "10px",
+                                        padding: "20px",
                                     }}
                                 >
-                                    {announcement.content}
-                                </Typography>
-                            </Card>
-                        );
-                    })}
+                                    <Typography
+                                        variant="body1"
+                                        sx={{
+                                            width: "100%",
+                                            whiteSpace: "pre-line",
+                                        }}
+                                    >
+                                        {announcement.content}
+                                    </Typography>
+                                </Card>
+                            );
+                        })}
                     {visibleAnnouncements < announcements.length && (
                         <Box
                             sx={{

--- a/src/pages/Catalog.tsx
+++ b/src/pages/Catalog.tsx
@@ -251,7 +251,7 @@ const Catalog = () => {
                             <Button
                                 variant="contained"
                                 onClick={() =>
-                                    setVisibleAnnouncements((prev) => prev + 2)
+                                    setVisibleAnnouncements((prev) => prev + 3)
                                 }
                             >
                                 Show More

--- a/src/pages/Catalog.tsx
+++ b/src/pages/Catalog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "../supabaseClient";
 
-import { Box, useMediaQuery, Typography, Card } from "@mui/material";
+import { Box, useMediaQuery, Typography, Card, Button } from "@mui/material";
 import { Masonry } from "@mui/lab";
 
 import OrgCard from "../comps/pages/catalog/OrgCard";
@@ -59,6 +59,7 @@ const Catalog = () => {
     );
 
     const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+    const [visibleAnnouncements, setVisibleAnnouncements] = useState(3);
 
     const isTwo = useMediaQuery("(max-width: 1525px)");
     const isTwoWrap = useMediaQuery("(max-width: 1100px)");
@@ -160,7 +161,8 @@ const Catalog = () => {
         const fetchAnnouncements = async () => {
             const { data, error } = await supabase
                 .from("announcements")
-                .select("*");
+                .select("*")
+                .order("created_at", { ascending: false }); // Sort by created_at in descending order
 
             if (error || !data) {
                 enqueueSnackbar(
@@ -175,7 +177,6 @@ const Catalog = () => {
 
         fetchAnnouncements();
     }, [enqueueSnackbar, setAnnouncements]);
-
     /*
   Testing
   useEffect(() => {
@@ -183,6 +184,10 @@ const Catalog = () => {
     console.log(`${Object.keys(getUnique(orgs)).length} unique orgs!`);
   }, [orgs])
   */
+
+    const loadMoreAnnouncements = () => {
+        setVisibleAnnouncements((prev) => prev + 2);
+    };
 
     let approvedOrgs = searchState.orgs.filter(
         (o) => o.state !== "PENDING" && o.state !== "LOCKED",
@@ -214,30 +219,49 @@ const Catalog = () => {
                     }}
                 >
                     <Typography variant="h3">Announcements</Typography>
-                    {announcements.map((announcement, i) => {
-                        return (
-                            <Card
-                                key={i}
-                                sx={{
-                                    width: "100%",
-                                    display: "flex",
-                                    justifyContent: "center",
-                                    marginTop: "10px",
-                                    padding: "20px",
-                                }}
-                            >
-                                <Typography
-                                    variant="body1"
+                    {announcements
+                        .slice(0, visibleAnnouncements)
+                        .map((announcement, i) => {
+                            return (
+                                <Card
+                                    key={i}
                                     sx={{
                                         width: "100%",
-                                        whiteSpace: "pre-line",
+                                        display: "flex",
+                                        justifyContent: "center",
+                                        marginTop: "10px",
+                                        padding: "20px",
                                     }}
                                 >
-                                    {announcement.content}
-                                </Typography>
-                            </Card>
-                        );
-                    })}
+                                    <Typography
+                                        variant="body1"
+                                        sx={{
+                                            width: "100%",
+                                            whiteSpace: "pre-line",
+                                        }}
+                                    >
+                                        {announcement.content}
+                                    </Typography>
+                                </Card>
+                            );
+                        })}
+                    {visibleAnnouncements < announcements.length && (
+                        <Box
+                            sx={{
+                                width: "100%",
+                                display: "flex",
+                                justifyContent: "center",
+                                marginTop: "10px",
+                            }}
+                        >
+                            <Button
+                                variant="contained"
+                                onClick={loadMoreAnnouncements}
+                            >
+                                Show More
+                            </Button>
+                        </Box>
+                    )}
                 </Box>
                 <Typography variant="h3">Catalog</Typography>
 

--- a/src/pages/admin/Announcements.tsx
+++ b/src/pages/admin/Announcements.tsx
@@ -185,7 +185,7 @@ const Announcements = () => {
                         <Button
                             variant="contained"
                             onClick={() =>
-                                setVisibleAnnouncements((prev) => prev + 2)
+                                setVisibleAnnouncements((prev) => prev + 3)
                             }
                         >
                             Show More

--- a/src/pages/admin/Announcements.tsx
+++ b/src/pages/admin/Announcements.tsx
@@ -7,12 +7,14 @@ const Announcements = () => {
     let [content, setContent] = useState("");
     let { enqueueSnackbar } = useSnackbar();
     let [announcements, setAnnouncements] = useState<Announcement[]>([]);
+    const [visibleAnnouncements, setVisibleAnnouncements] = useState(3);
 
     useEffect(() => {
         const fetchAnnouncements = async () => {
             const { data, error } = await supabase
                 .from("announcements")
-                .select("*");
+                .select("*")
+                .order("created_at", { ascending: false });
 
             if (error || !data) {
                 enqueueSnackbar(
@@ -122,53 +124,74 @@ const Announcements = () => {
                     justifyContent: "center",
                 }}
             >
-                {announcements.map((announcement, i) => {
-                    return (
-                        <Box
-                            key={i}
-                            sx={{
-                                width: "100%",
-                                display: "flex",
-                                flexWrap: "wrap",
-                                justifyContent: "center",
-                                marginTop: "10px",
-                            }}
-                        >
-                            <Card
+                {announcements
+                    .slice(0, visibleAnnouncements)
+                    .map((announcement, i) => {
+                        return (
+                            <Box
+                                key={i}
                                 sx={{
-                                    maxWidth: "600px",
                                     width: "100%",
                                     display: "flex",
-                                    padding: "10px",
-                                    alignItems: "center",
+                                    flexWrap: "wrap",
+                                    justifyContent: "center",
+                                    marginTop: "10px",
                                 }}
                             >
-                                <Typography
-                                    variant="body1"
+                                <Card
                                     sx={{
-                                        width: "80%",
-                                        whiteSpace: "pre-line",
+                                        maxWidth: "600px",
+                                        width: "100%",
+                                        display: "flex",
+                                        padding: "10px",
+                                        alignItems: "center",
                                     }}
                                 >
-                                    {announcement.content}
-                                </Typography>
-                                <Button
-                                    onClick={() =>
-                                        deleteAnnouncement(announcement.id)
-                                    }
-                                    sx={{
-                                        width: "15%",
-                                        marginLeft: "20px",
-                                        height: "40px",
-                                    }}
-                                    variant="contained"
-                                >
-                                    Delete
-                                </Button>
-                            </Card>
-                        </Box>
-                    );
-                })}
+                                    <Typography
+                                        variant="body1"
+                                        sx={{
+                                            width: "80%",
+                                            whiteSpace: "pre-line",
+                                        }}
+                                    >
+                                        {announcement.content}
+                                    </Typography>
+                                    <Button
+                                        onClick={() =>
+                                            deleteAnnouncement(announcement.id)
+                                        }
+                                        sx={{
+                                            width: "15%",
+                                            marginLeft: "20px",
+                                            height: "40px",
+                                        }}
+                                        variant="contained"
+                                    >
+                                        Delete
+                                    </Button>
+                                </Card>
+                            </Box>
+                        );
+                    })}
+                {visibleAnnouncements < announcements.length && (
+                    <Box
+                        sx={{
+                            width: "100%",
+                            display: "flex",
+                            justifyContent: "center",
+                            marginTop: "10px",
+                        }}
+                    >
+                        <Button
+                            variant="contained"
+                            onClick={() =>
+                                setVisibleAnnouncements((prev) => prev + 2)
+                            }
+                        >
+                            Show More
+                        </Button>
+                    </Box>
+                )}
             </Box>
         </Box>
     );


### PR DESCRIPTION
Fixes #124 by showing 3 (i chose this number at random) announcements at a time and by clicking "Show More" button, it shows 2 (i chose this number at random) more announcements at a time. Also, announcements are sorted and displayed in reverse order from latest coming first to earliest coming last.

Notes: Have not implemented urgent announcements. 