### PR TITLE
Fixed #144 - Fixed user losing progress in charter

### DIFF
--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -167,22 +167,27 @@ const Create = () => {
     useEffect(() => {
         if (!user.signed_in) {
             navigate("/");
-            return;
-        }
-    }, [user, navigate]);
-
-    useEffect(() => {
-        if (!user.signed_in) {
             enqueueSnackbar(
                 "You must be signed in to create an organization.",
                 {
                     variant: "warning",
                 },
             );
-            navigate("/");
             return;
         }
-    }, [user, navigate]);
+    }, [user, navigate, enqueueSnackbar]);
+
+    useEffect(() => {
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+        };
+
+        window.addEventListener("beforeunload", handleBeforeUnload);
+
+        return () => {
+            window.removeEventListener("beforeunload", handleBeforeUnload);
+        };
+    }, []);
 
     return (
         <MultiPageForm


### PR DESCRIPTION
Fixes #144  - Using the beforeunload event, a browser dialog opens up when the user is in charter and tries to reload/leave the site.

Cleaned up the not signed in user effect hook.