### PR TITLE
Restyle links to use theming

### DIFF
--- a/src/comps/pages/orgs/OrgNav.tsx
+++ b/src/comps/pages/orgs/OrgNav.tsx
@@ -8,6 +8,7 @@ import {
     ListItemButton,
     ListItemText,
     ListItemIcon,
+    Link,
     Avatar,
 } from "@mui/material";
 
@@ -17,7 +18,7 @@ import UserContext from "../../context/UserContext";
 import { supabase } from "../../../supabaseClient";
 import { useSnackbar } from "notistack";
 
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link as NavLink, useLocation, useNavigate } from "react-router-dom";
 import InfoIcon from "@mui/icons-material/Info";
 import ArticleIcon from "@mui/icons-material/Article";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
@@ -263,6 +264,7 @@ const OrgNav = ({ isMobile }: { isMobile: boolean }) => {
                         return (
                             <Link
                                 key={i}
+                                component={NavLink}
                                 to={social}
                                 style={{ textAlign: "center" }}
                             >

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -1,5 +1,5 @@
-import { Box, Typography } from "@mui/material";
-import { useNavigate, Link } from "react-router-dom";
+import { Box, Link, Typography } from "@mui/material";
+import { useNavigate, Link as RouterLink } from "react-router-dom";
 import AsyncButton from "../comps/ui/AsyncButton";
 
 const Rules = () => {
@@ -34,7 +34,8 @@ const Rules = () => {
                         each week, Saturday. Once fully approved, the charter
                         will be visible on the&nbsp;
                         <Link
-                            color="secondary"
+                            color="primary"
+                            component={RouterLink}
                             to="https://epsilon.stuysu.org/catalog"
                         >
                             Epsilon website
@@ -71,15 +72,19 @@ const Rules = () => {
                         All Activities must adhere to the New York City
                         Department of Education{" "}
                         <Link
-                            color="secondary"
-                            to="https://www.schools.nyc.gov/docs/default-source/default-document-library/a-601-english"
+                            color="primary"
+                            href="https://www.schools.nyc.gov/docs/default-source/default-document-library/a-601-english"
+                            target="_blank"
+                            rel="noreferrer"
                         >
                             Chancellor’s Regulation A-601
                         </Link>
                         . Any Activity that violates this regulation or other{" "}
                         <Link
-                            color="secondary"
-                            to="https://www.schools.nyc.gov/about-us/policies/chancellors-regulations"
+                            color="primary"
+                            href="https://www.schools.nyc.gov/about-us/policies/chancellors-regulations"
+                            target="_blank"
+                            rel="noreferrer"
                         >
                             Chancellor’s Regulations
                         </Link>
@@ -89,8 +94,10 @@ const Rules = () => {
                     <li>
                         All Activities must adhere to the{" "}
                         <Link
-                            color="secondary"
-                            to="https://stuy.enschool.org/apps/pages/index.jsp?uREC_ID=126635&type=d"
+                            color="primary"
+                            href="https://stuy.enschool.org/apps/pages/index.jsp?uREC_ID=126635&type=d"
+                            target="_blank"
+                            rel="noreferrer"
                         >
                             Stuyvesant Code of Conduct
                         </Link>


### PR DESCRIPTION
Before this patch, the links in the rules page displayed as plain <a> tags with default blue/purple coloration (poor contrast on dark mode).

Also sets external links to open in a new tab.