### PR TITLE
Rewrite infinite scroll logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
                 "react-custom-scrollbars-2": "^4.5.0",
                 "react-dom": "^18.2.0",
                 "react-helmet": "^6.1.0",
-                "react-infinite-scroll-component": "^6.1.0",
                 "react-measure": "^2.5.2",
                 "react-multi-carousel": "^2.8.5",
                 "react-router-dom": "^6.22.0",
@@ -15880,17 +15879,6 @@
                 "react": ">=16.3.0"
             }
         },
-        "node_modules/react-infinite-scroll-component": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz",
-            "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
-            "dependencies": {
-                "throttle-debounce": "^2.1.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.0.0"
-            }
-        },
         "node_modules/react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -17889,14 +17877,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
             "integrity": "sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ=="
-        },
-        "node_modules/throttle-debounce": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
-            "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/thunky": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "react-custom-scrollbars-2": "^4.5.0",
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
-        "react-infinite-scroll-component": "^6.1.0",
         "react-measure": "^2.5.2",
         "react-multi-carousel": "^2.8.5",
         "react-router-dom": "^6.22.0",

--- a/src/pages/Catalog.tsx
+++ b/src/pages/Catalog.tsx
@@ -70,9 +70,7 @@ const Catalog = () => {
     if (isOne) columns = 1;
 
     const getOrgs = async (searchState: SearchState, isReset?: boolean) => {
-        console.log("GETTING ORGS");
         const originalOffset = isReset ? 0 : searchState.offset;
-        console.log({ isReset, originalOffset, searchState });
         // setSearchState({...searchState, offset: originalOffset + querySize});
 
         let orgData, orgError;
@@ -210,18 +208,10 @@ const Catalog = () => {
             }
         };
     }, [loadingObserver, searchState]);
-    /*
-  Testing
-  useEffect(() => {
-    console.log(`${orgs.length} orgs!`)
-    console.log(`${Object.keys(getUnique(orgs)).length} unique orgs!`);
-  }, [orgs])
-  */
 
     let approvedOrgs = searchState.orgs.filter(
         (o) => o.state !== "PENDING" && o.state !== "LOCKED",
     );
-    console.log(searchState);
 
     return (
         <Box sx={{ display: "flex", position: "relative", flexWrap: "wrap" }}>

--- a/src/pages/Catalog.tsx
+++ b/src/pages/Catalog.tsx
@@ -7,8 +7,6 @@ import { Masonry } from "@mui/lab";
 import OrgCard from "../comps/pages/catalog/OrgCard";
 import { useSnackbar } from "notistack";
 
-import InfiniteScroll from "react-infinite-scroll-component";
-
 import Loading from "../comps/ui/Loading";
 import SearchFilter from "../comps/pages/catalog/SearchFilter";
 import AsyncButton from "../comps/ui/AsyncButton";
@@ -71,6 +69,7 @@ const Catalog = () => {
     if (isOne) columns = 1;
 
     const getOrgs = async (isReset?: boolean) => {
+        console.log("GETTING ORGS");
         const originalOffset = isReset ? 0 : searchState.offset;
         // setSearchState({...searchState, offset: originalOffset + querySize});
 
@@ -192,6 +191,7 @@ const Catalog = () => {
     let approvedOrgs = searchState.orgs.filter(
         (o) => o.state !== "PENDING" && o.state !== "LOCKED",
     );
+    console.log(searchState);
 
     return (
         <Box sx={{ display: "flex", position: "relative", flexWrap: "wrap" }}>
@@ -267,15 +267,26 @@ const Catalog = () => {
                 </Box>
                 <Typography variant="h3">Catalog</Typography>
 
-                <InfiniteScroll
-                    dataLength={searchState.offset}
-                    next={getOrgs}
-                    hasMore={searchState.more}
-                    loader={<Loading />}
-                    endMessage={
+                <Box>
+                    {searchState.orgs.length ? (
+                        <Masonry columns={columns} spacing={2}>
+                            {searchState.orgs.map((org, i) => {
+                                return <OrgCard organization={org} key={i} />;
+                            })}
+                        </Masonry>
+                    ) : (
+                        <></>
+                    )}
+                    {searchState.more ? (
+                        <Loading />
+                    ) : (
                         <Box>
                             {approvedOrgs.length === 0 ? (
-                                <Typography align="center" variant="h3">
+                                <Typography
+                                    align="center"
+                                    variant="h3"
+                                    sx={{ paddingTop: "1em" }}
+                                >
                                     No Organizations Found.
                                 </Typography>
                             ) : (
@@ -285,23 +296,8 @@ const Catalog = () => {
                                 </Typography>
                             )}
                         </Box>
-                    }
-                    style={{ overflow: "hidden", paddingTop: "20px" }}
-                >
-                    <Masonry columns={columns} spacing={2}>
-                        {
-                            searchState.orgs.length ? (
-                                searchState.orgs.map((org, i) => {
-                                    return (
-                                        <OrgCard organization={org} key={i} />
-                                    );
-                                })
-                            ) : (
-                                <Box></Box>
-                            ) /* To make masonry resize accordingly */
-                        }
-                    </Masonry>
-                </InfiniteScroll>
+                    )}
+                </Box>
             </Box>
         </Box>
     );


### PR DESCRIPTION
The previous infinite scroll component has not been maintained in over 3 years, and fails to work on our site.

As a replacement, we can manually use observers to trigger load when the loading circle is visible. However, the change in contents for the search state is slightly jittery, with the masonry shifting layouts.

Fixes #197 