### PR TITLE
Added settings page

### DIFF
--- a/src/comps/ui/nav/NavBar.tsx
+++ b/src/comps/ui/nav/NavBar.tsx
@@ -29,6 +29,7 @@ import { ThemeContext } from "../../context/ThemeProvider";
 import HomeIcon from "@mui/icons-material/Home";
 import PowerSettingsNewIcon from "@mui/icons-material/PowerSettingsNew";
 import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+import SettingsIcon from "@mui/icons-material/Settings";
 import FeedIcon from "@mui/icons-material/Feed";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
@@ -230,6 +231,16 @@ const NavBar = () => {
                                     <AdminPanelSettingsIcon />
                                 </ListItemIcon>
                                 <ListItemText>Admin</ListItemText>
+                            </ListItemButton>
+                        )}
+                        {user.signed_in && (
+                            <ListItemButton
+                                onClick={() => navigate("/settings")}
+                            >
+                                <ListItemIcon>
+                                    <SettingsIcon />
+                                </ListItemIcon>
+                                <ListItemText>Settings</ListItemText>
                             </ListItemButton>
                         )}
                     </List>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,215 @@
+import { Box, Paper, Switch, Typography } from "@mui/material";
+import { useContext, useEffect, useState } from "react";
+import UserContext from "../comps/context/UserContext";
+import { supabase } from "../supabaseClient";
+import { enqueueSnackbar } from "notistack";
+import LoginGate from "../comps/ui/LoginGate";
+
+type Memberships = {
+    organization_id: number;
+    allow_notifications: boolean;
+    organization_name?: string;
+};
+
+const Settings = () => {
+    const user = useContext(UserContext);
+    const [memberships, setMemberships] = useState<Memberships[]>([]);
+
+    useEffect(() => {
+        const fetchMemberships = async () => {
+            const { data: membershipsData, error: membershipsError } =
+                await supabase
+                    .from("memberships")
+                    .select(
+                        `
+                    organization_id,
+                    allow_notifications
+                `,
+                    )
+                    .eq("user_id", user.id)
+                    .returns<Memberships[]>();
+
+            if (membershipsError) {
+                enqueueSnackbar("Failed to fetch memberships", {
+                    variant: "error",
+                });
+                return;
+            }
+
+            if (membershipsData && membershipsData.length > 0) {
+                const organizationIds = membershipsData.map(
+                    (m) => m.organization_id,
+                );
+
+                const { data: organizationsData, error: organizationsError } =
+                    await supabase
+                        .from("organizations")
+                        .select("id, name")
+                        .in("id", organizationIds);
+
+                if (organizationsError) {
+                    enqueueSnackbar("Failed to fetch organization names", {
+                        variant: "error",
+                    });
+                    return;
+                }
+
+                const mergedData = membershipsData.map((membership) => {
+                    const organization = organizationsData.find(
+                        (org) => org.id === membership.organization_id,
+                    );
+                    return {
+                        ...membership,
+                        organization_name: organization
+                            ? organization.name
+                            : "Unknown",
+                    };
+                });
+
+                setMemberships(mergedData);
+            }
+        };
+
+        fetchMemberships();
+    }, [user.id]);
+
+    const handleToggle = async (
+        organization_id: number,
+        currentValue: boolean,
+    ) => {
+        const { data, error } = await supabase
+            .from("memberships")
+            .update({ allow_notifications: !currentValue })
+            .eq("organization_id", organization_id)
+            .eq("user_id", user.id);
+
+        if (error) {
+            enqueueSnackbar("Failed to update notification settings", {
+                variant: "error",
+            });
+            return;
+        }
+
+        setMemberships((prevMemberships) =>
+            prevMemberships.map((membership) =>
+                membership.organization_id === organization_id
+                    ? { ...membership, allow_notifications: !currentValue }
+                    : membership,
+            ),
+        );
+        enqueueSnackbar("Notification settings updated successfully", {
+            variant: "success",
+        });
+    };
+
+    return (
+        <LoginGate sx={{ width: "100%", paddingLeft: "20px" }}>
+            <Box
+                sx={{
+                    width: "100%",
+                    textAlign: "center",
+                    marginBottom: "30px",
+                }}
+            >
+                <Typography variant="h1" align="center" marginBottom="50px">
+                    Email Settings
+                </Typography>
+            </Box>
+
+            <Box
+                sx={{
+                    width: "100%",
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                }}
+            >
+                <Box
+                    sx={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        width: "43%",
+                        mb: 2,
+                    }}
+                >
+                    <Typography
+                        variant="h2"
+                        sx={{
+                            fontSize: "2rem",
+                            textAlign: "left",
+                            width: "45%",
+                        }}
+                    >
+                        Organization Name
+                    </Typography>
+                    <Typography
+                        variant="h2"
+                        sx={{
+                            fontSize: "2rem",
+                            textAlign: "right",
+                            width: "45%",
+                        }}
+                    >
+                        Allow Notifications
+                    </Typography>
+                </Box>
+
+                <Box
+                    sx={{
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        width: "45%",
+                    }}
+                >
+                    {memberships.map((membership) => (
+                        <Paper
+                            key={membership.organization_id}
+                            elevation={1}
+                            sx={{
+                                width: "100%",
+                                borderRadius: "7px",
+                                marginBottom: "15px",
+                                padding: "10px",
+                                display: "flex",
+                                justifyContent: "space-between",
+                                alignItems: "center",
+                            }}
+                        >
+                            <Typography
+                                sx={{
+                                    fontSize: "1.5rem",
+                                    flex: 1,
+                                    paddingLeft: "3%",
+                                }}
+                            >
+                                {membership.organization_name}
+                            </Typography>
+                            <Box
+                                sx={{
+                                    display: "flex",
+                                    justifyContent: "center",
+                                    alignItems: "center",
+                                    paddingRight: "11%",
+                                }}
+                            >
+                                <Switch
+                                    checked={membership.allow_notifications}
+                                    onChange={() =>
+                                        handleToggle(
+                                            membership.organization_id,
+                                            membership.allow_notifications,
+                                        )
+                                    }
+                                    color="primary"
+                                />
+                            </Box>
+                        </Paper>
+                    ))}
+                </Box>
+            </Box>
+        </LoginGate>
+    );
+};
+
+export default Settings;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -89,7 +89,7 @@ const Settings = () => {
             .eq("user_id", user.id)
             .select();
 
-        if (error || !data || data[0].allow_notifications !== !currentValue) {
+        if (error || !data || data?.length < 1 || data[0].allow_notifications !== !currentValue) {
             enqueueSnackbar("Failed to update notification settings", {
                 variant: "error",
             });

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -86,9 +86,10 @@ const Settings = () => {
             .from("memberships")
             .update({ allow_notifications: !currentValue })
             .eq("organization_id", organization_id)
-            .eq("user_id", user.id);
+            .eq("user_id", user.id)
+            .select();
 
-        if (error) {
+        if (error || !data || data[0].allow_notifications === !currentValue) {
             enqueueSnackbar("Failed to update notification settings", {
                 variant: "error",
             });

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -89,7 +89,7 @@ const Settings = () => {
             .eq("user_id", user.id)
             .select();
 
-        if (error || !data || data[0].allow_notifications === !currentValue) {
+        if (error || !data || data[0].allow_notifications !== !currentValue) {
             enqueueSnackbar("Failed to update notification settings", {
                 variant: "error",
             });

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -65,6 +65,11 @@ const Settings = () => {
                             : "Unknown",
                     };
                 });
+                mergedData.sort((membershipA, membershipB) =>
+                    membershipA.organization_name.localeCompare(
+                        membershipB.organization_name,
+                    ),
+                );
 
                 setMemberships(mergedData);
             }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -33,12 +33,15 @@ const Settings = () => {
 
             if (membershipsData && membershipsData.length > 0) {
                 const membershipIds = membershipsData.map((m) => m.id);
-                const organizationIds = membershipsData.map((m) => m.organization_id);
+                const organizationIds = membershipsData.map(
+                    (m) => m.organization_id,
+                );
 
-                const { data: notificationsData, error: notificationsError } = await supabase
-                    .from("membershipnotifications")
-                    .select("membership_id, allow_notifications")
-                    .in("membership_id", membershipIds);
+                const { data: notificationsData, error: notificationsError } =
+                    await supabase
+                        .from("membershipnotifications")
+                        .select("membership_id, allow_notifications")
+                        .in("membership_id", membershipIds);
 
                 if (notificationsError) {
                     enqueueSnackbar("Failed to fetch notification settings", {
@@ -62,16 +65,20 @@ const Settings = () => {
 
                 const mergedData = membershipsData.map((membership) => {
                     const notification = notificationsData.find(
-                        (n) => n.membership_id === membership.id
+                        (n) => n.membership_id === membership.id,
                     );
                     const organization = organizationsData.find(
-                        (org) => org.id === membership.organization_id
+                        (org) => org.id === membership.organization_id,
                     );
 
                     return {
                         ...membership,
-                        allow_notifications: notification ? notification.allow_notifications : true,
-                        organization_name: organization ? organization.name : "Unknown",
+                        allow_notifications: notification
+                            ? notification.allow_notifications
+                            : true,
+                        organization_name: organization
+                            ? organization.name
+                            : "Unknown",
                     };
                 });
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,6 +14,7 @@ import Rules from "./Rules";
 
 const ModuleRouter = lazy(() => import("./modules/ModuleRouter"));
 const Catalog = lazy(() => import("./Catalog"));
+const Settings = lazy(() => import("./Settings"));
 const Create = lazy(() => import("./Create"));
 const OrgRouter = lazy(() => import("./orgs"));
 const AdminRouter = lazy(() => import("./admin"));
@@ -45,6 +46,7 @@ const Pages = () => {
                 <Routes>
                     <Route path={"/"} Component={Home} />
                     <Route path={"/catalog"} Component={Catalog} />
+                    <Route path={"/settings"} Component={Settings} />
                     <Route path={"/create"} Component={Create} />
                     <Route path={"/about"} Component={About} />
                     <Route path={"/meetings"} Component={AllMeetings} />


### PR DESCRIPTION
Added settings page, which allows users to toggle notifications settings by manipulating the boolean column allow_notifications in the memberships table.

Problems:
- Toggle/manipulation of the table is only available to admin (should be allowed for all members)