### PR TITLE
Social links of clubs now open in new tabs

### DIFF
--- a/src/comps/pages/orgs/OrgNav.tsx
+++ b/src/comps/pages/orgs/OrgNav.tsx
@@ -266,8 +266,9 @@ const OrgNav = ({ isMobile }: { isMobile: boolean }) => {
                         return (
                             <Link
                                 key={i}
-                                component={NavLink}
-                                to={social}
+                                href={social}
+                                target="_blank"
+                                rel="noopener noreferrer"
                                 style={{ textAlign: "center" }}
                             >
                                 {social}


### PR DESCRIPTION
Fixes issue #234, and social links of clubs now open in a new tab rather than the current Epsilon tab.