### PR TITLE
Fix meeting description opening when trying to edit a meeting

### DIFF
--- a/src/components/ui/buttons/AsyncButton.tsx
+++ b/src/components/ui/buttons/AsyncButton.tsx
@@ -3,7 +3,9 @@ import { ButtonProps } from "@mui/material/Button";
 import { ButtonBase, SxProps, Theme } from "@mui/material";
 
 interface AsyncButtonProps extends ButtonProps {
-    onClick?: () => void | Promise<any>;
+    onClick?: (
+        e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    ) => void | Promise<any>;
     sx?: SxProps<Theme>;
     isPrimary?: boolean;
 }
@@ -17,11 +19,13 @@ const AsyncButton: React.FC<AsyncButtonProps> = ({
 }) => {
     const [isLoading, setIsLoading] = useState(false);
 
-    const handleClick = async () => {
+    const handleClick = async (
+        e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    ) => {
         setIsLoading(true);
         try {
             if (onClick) {
-                const result = onClick();
+                const result = onClick(e);
                 if (result instanceof Promise) {
                     await result;
                 }
@@ -33,7 +37,9 @@ const AsyncButton: React.FC<AsyncButtonProps> = ({
 
     return (
         <ButtonBase
-            onClick={handleClick}
+            onClick={(e) => {
+                handleClick(e);
+            }}
             sx={{
                 fontFamily: "inter-variable",
                 fontVariationSettings: "'wght' 700",

--- a/src/modules/stuyactivities/orgs/components/OrgMeeting.tsx
+++ b/src/modules/stuyactivities/orgs/components/OrgMeeting.tsx
@@ -46,12 +46,11 @@ const OrgMeeting = ({
 
     return (
         <div className={"w-full cursor-pointer"}>
-            <div className="flex justify-between items-center bg-layer-2 transition-colors sm:hover:bg-layer-3 p-4"
-                 onClick={() => setOpen(true)}
+            <div
+                className="flex justify-between items-center bg-layer-2 transition-colors sm:hover:bg-layer-3 p-4"
+                onClick={() => setOpen(true)}
             >
-                <div
-                    className={"w-full flex justify-between items-center"}
-                >
+                <div className={"w-full flex justify-between items-center"}>
                     <div className="w-full pt-1">
                         <h4>{title}</h4>
                         <p>
@@ -80,7 +79,10 @@ const OrgMeeting = ({
                     {onEdit && (
                         <AsyncButton
                             variant="contained"
-                            onClick={onEdit}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onEdit();
+                            }}
                             sx={{ marginLeft: "10px" }}
                         >
                             Edit


### PR DESCRIPTION
From @gdjolt8 on PR #357

Fixes meeting description opening when trying to edit a club meeting, blocking the user from interacting with the edit meeting window and forcing the user to interact with the meeting description popup

Fixes #356