### PR TITLE
Fix for issue 105

### DIFF
--- a/src/modules/stuyactivities/orgs/org_admin/components/PostEditor.tsx
+++ b/src/modules/stuyactivities/orgs/org_admin/components/PostEditor.tsx
@@ -110,26 +110,28 @@ const PostEditor = ({
             description: postData.description,
         };
 
+        // There is no need for .limits(1) since id is primary_key/unique
         let { data, error } = await supabase
             .from("posts")
             .update(payload)
             .eq("id", postData.id)
-            .select();
+            .select()
+            .single();
 
-        if (error || !data) {
+        if (error) {
             return enqueueSnackbar(
                 "Could not update post. Please contact it@stuysu.org for support.",
                 { variant: "error" },
             );
         }
 
-        data[0].organizations = {
+        data.organizations = {
             id: orgId,
             name: orgName,
             picture: orgPicture,
         };
 
-        if (onSave) onSave(data[0] as Post);
+        if (onSave) onSave(data as Post);
         enqueueSnackbar("Post updated!", { variant: "success" });
     };
 


### PR DESCRIPTION
Fix #105

There is no need for .limits(1) since id is primary_key/unique, because when I was testing, I tried setting two rows with the same postId, but the database ensures that id will be unique. Thus, it is unnecessary to run `limits(1)`. When I hardcoded a fake id, the error was not null so there is no reason to be checking data. I did not use `maybesingle()` because that would make empty rows not an error and we would then need the code `|| !data`.

Tested: 
* By editing the post and observing it's properly saved. 
* Temporarily added `console.log(data, error)` and hardcoded non-existing id. I observed that error is
```
{
    "code": "PGRST116",
    "details": "The result contains 0 rows",
    "hint": null,
    "message": "Cannot coerce the result to a single JSON object"
} 
```
that we see red status update as expected.
